### PR TITLE
Update auto_save.py

### DIFF
--- a/auto_save.py
+++ b/auto_save.py
@@ -56,7 +56,7 @@ class AutoSaveListener(sublime_plugin.EventListener):
       '''
       Must use this callback for ST2 compatibility
       '''
-      if view.is_dirty() and not view.is_loading():
+      if view.is_dirty() and not view.is_loading() and not view.is_auto_complete_visible():
         if not backup: # Save file
           view.run_command("save")
         else: # Save backup file


### PR DESCRIPTION
Prevent call to save if auto complete is visible. 

Note This change causes the save not to get called when auto complete popup is visible. So any file changes made while auto complete is visible is not saved.

This is a solution for the issue discussed in [https://github.com/jamesfzhang/auto-save/issues/21]  and [https://github.com/jamesfzhang/auto-save/issues/7]